### PR TITLE
Working Tests

### DIFF
--- a/MParT/Distributions/DensityBase.h
+++ b/MParT/Distributions/DensityBase.h
@@ -47,8 +47,10 @@ public:
      * @param X The points where we want to evaluate the log density.
      * @return Matrix \f$A\in\mathbb{R}^{m\times n}\f$ containing the log density at each point.
      */
-    template<typename AnyMemorySpace>
-    StridedVector<double, AnyMemorySpace> LogDensity(StridedMatrix<const double, AnyMemorySpace> const &X);
+    StridedVector<double, MemorySpace> LogDensity(StridedMatrix<const double, MemorySpace> const &X);
+    #if defined(MPART_ENABLE_GPU)
+    StridedVector<double, std::conditional_t< std::is_same_v<MemorySpace, Kokkos::HostSpace> , DeviceSpace, Kokkos::HostSpace> > LogDensity(StridedMatrix<const double, std::conditional_t< std::is_same_v<MemorySpace, Kokkos::HostSpace> , DeviceSpace, Kokkos::HostSpace > > const &X);
+    #endif
 
     /**
      * @brief Computes the log density at the given points.
@@ -66,8 +68,10 @@ public:
      * @param X The points where we want to evaluate the gradient log density.
      * @return A matrix \f$A\in\mathbb{R}^{m\times n}\f$ containing the gradient of the log density at each point.
      */
-    template<typename AnyMemorySpace>
-    StridedMatrix<double, AnyMemorySpace> LogDensityInputGrad(StridedMatrix<const double, AnyMemorySpace> const &X);
+    StridedMatrix<double, MemorySpace> LogDensityInputGrad(StridedMatrix<const double, MemorySpace> const &X);
+    #if defined(MPART_ENABLE_GPU)
+    StridedMatrix<double, std::conditional_t< std::is_same_v<MemorySpace, Kokkos::HostSpace> , DeviceSpace, Kokkos::HostSpace> > LogDensityInputGrad(StridedMatrix<const double, std::conditional_t< std::is_same_v<MemorySpace, Kokkos::HostSpace> , DeviceSpace, Kokkos::HostSpace > > const &X);
+    #endif
 
     /**
      * @brief Returns the input dimension of the density

--- a/MParT/Distributions/PushforwardDensity.h
+++ b/MParT/Distributions/PushforwardDensity.h
@@ -46,7 +46,7 @@ class PushforwardDensity: public DensityBase<MemorySpace> {
         StridedMatrix<double, MemorySpace> mappedPts = map_->Inverse(prefix_null, pts);
         density_->LogDensityImpl(mappedPts, output);
         StridedVector<double, MemorySpace> logJacobian = map_->LogDeterminant(mappedPts);
-	Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy{0, output.extent(0)};
+	Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy{0lu, output.extent(0)};
         Kokkos::parallel_for("Subtract logJac", policy, KOKKOS_LAMBDA(const unsigned int i){
             output(i) -= logJacobian(i);
         });

--- a/MParT/ParameterizedFunctionBase.h
+++ b/MParT/ParameterizedFunctionBase.h
@@ -51,7 +51,7 @@ namespace mpart {
             @param coeffs A view containing the coefficients to copy.
         */
        virtual void SetCoeffs(Kokkos::View<const double*, MemorySpace> coeffs);
-       void SetCoeffs(Kokkos::View<double*, MemorySpace> coeffs);
+               void SetCoeffs(Kokkos::View<      double*, MemorySpace> coeffs);
 
 
         /** @brief Wrap the internal coefficient view around another view.
@@ -64,8 +64,8 @@ namespace mpart {
 
         #if defined(MPART_ENABLE_GPU)
         virtual void SetCoeffs(Kokkos::View<const double*, std::conditional_t<std::is_same_v<Kokkos::HostSpace,MemorySpace>, mpart::DeviceSpace, Kokkos::HostSpace>> coeffs);
-	virtual void SetCoeffs(Kokkos::View<double*, std::conditional_t<std::is_same_v<Kokkos::HostSpace,MemorySpace>, mpart::DeviceSpace, Kokkos::HostSpace>> coeffs);
-	#endif
+	            void SetCoeffs(Kokkos::View<      double*, std::conditional_t<std::is_same_v<Kokkos::HostSpace,MemorySpace>, mpart::DeviceSpace, Kokkos::HostSpace>> coeffs);
+	    #endif
 
         /** SetCoeffs function with conversion from Eigen to Kokkos vector types.*/
         virtual void SetCoeffs(Eigen::Ref<Eigen::VectorXd> coeffs);

--- a/MParT/Quadrature.h
+++ b/MParT/Quadrature.h
@@ -9,6 +9,8 @@
 
 #include <Eigen/Core>
 
+#include "MParT/Utilities/KokkosSpaceMappings.h"
+
 #if defined(MPART_HAS_CEREAL)
 #include <cereal/access.hpp>
 #include <cereal/types/base_class.hpp>
@@ -353,8 +355,8 @@ struct GetRuleFunctor{
 template<typename MemorySpace>
 inline ClenshawCurtisQuadrature<MemorySpace>::ClenshawCurtisQuadrature(unsigned int numPts, unsigned int maxDim) : QuadratureBase<MemorySpace>(maxDim,maxDim),  pts_("Points", numPts), wts_("Weights", numPts), numPts_(numPts)
 {
-    // TODO: Add parallel for loop here with one thread to make sure rule is filled in the correct space
-    Kokkos::parallel_for(1, GetRuleFunctor<MemorySpace>(numPts, pts_.data(), wts_.data()));
+    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy {0,1};
+    Kokkos::parallel_for(policy, GetRuleFunctor<MemorySpace>(numPts, pts_.data(), wts_.data()));
 };
 
 template<>
@@ -367,8 +369,8 @@ inline ClenshawCurtisQuadrature<Kokkos::HostSpace>::ClenshawCurtisQuadrature(uns
 template<typename MemorySpace>
 inline ClenshawCurtisQuadrature<MemorySpace>::ClenshawCurtisQuadrature(unsigned int numPts, unsigned int maxDim, double* workspace) : QuadratureBase<MemorySpace>(maxDim,maxDim,workspace),  pts_("Points", numPts), wts_("Weights", numPts), numPts_(numPts)
 {
-    // TODO: Add parallel for loop here with one thread to make sure rule is filled in the correct space
-    Kokkos::parallel_for(1, GetRuleFunctor<MemorySpace>(numPts, pts_.data(), wts_.data()));
+    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy {0,1};
+    Kokkos::parallel_for(policy, GetRuleFunctor<MemorySpace>(numPts, pts_.data(), wts_.data()));
 };
 
 template<>
@@ -1020,9 +1022,9 @@ inline AdaptiveClenshawCurtis<MemorySpace>::AdaptiveClenshawCurtis(unsigned int 
                                                             fineWts_("Coarse Pts", std::pow(2,level+1)+1)
 {
     assert(std::pow(2,level)+1 >=3);
-
-    Kokkos::parallel_for(1, GetRuleFunctor<MemorySpace>(std::pow(2,level)+1, coarsePts_.data(), coarseWts_.data()));
-    Kokkos::parallel_for(1, GetRuleFunctor<MemorySpace>(std::pow(2,level+1)+1, finePts_.data(), fineWts_.data()));
+    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy {0,1};
+    Kokkos::parallel_for(policy, GetRuleFunctor<MemorySpace>(std::pow(2,level)+1, coarsePts_.data(), coarseWts_.data()));
+    Kokkos::parallel_for(policy, GetRuleFunctor<MemorySpace>(std::pow(2,level+1)+1, finePts_.data(), fineWts_.data()));
 };
 
 template<>
@@ -1060,9 +1062,9 @@ inline AdaptiveClenshawCurtis<MemorySpace>::AdaptiveClenshawCurtis(unsigned int 
                                                             fineWts_("Coarse Pts", std::pow(2,level+1)+1)
 {
     assert(std::pow(2,level)+1 >=3);
-
-    Kokkos::parallel_for(1, GetRuleFunctor<MemorySpace>(std::pow(2,level)+1, coarsePts_.data(), coarseWts_.data()));
-    Kokkos::parallel_for(1, GetRuleFunctor<MemorySpace>(std::pow(2,level+1)+1, finePts_.data(), fineWts_.data()));
+    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy {0, 1};
+    Kokkos::parallel_for(policy, GetRuleFunctor<MemorySpace>(std::pow(2,level)+1, coarsePts_.data(), coarseWts_.data()));
+    Kokkos::parallel_for(policy, GetRuleFunctor<MemorySpace>(std::pow(2,level+1)+1, finePts_.data(), fineWts_.data()));
 };
 
 template<>

--- a/MParT/Utilities/LinearAlgebra.h
+++ b/MParT/Utilities/LinearAlgebra.h
@@ -26,8 +26,8 @@ template<typename ViewType1, typename ViewType2>
 void AddInPlace(ViewType1 x, ViewType2 y) {
     constexpr size_t rank = GetViewRank<ViewType1>::Rank;
     if constexpr(rank == 1) {
-	Kokkos::RangePolicy<typename ViewType1::execution_space> policy(0,x.extent(0));
-        Kokkos::parallel_for(x.extent(0), KOKKOS_LAMBDA(const int i){x(i) += y(i);});
+        Kokkos::RangePolicy<typename ViewType1::execution_space> policy(0,x.extent(0));
+        Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int i){x(i) += y(i);});
     } else if (rank == 2) {
         Kokkos::MDRangePolicy<Kokkos::Rank<2>,typename ViewType1::execution_space> policy({0, 0}, {x.extent(0), x.extent(1)});
         Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const int i, const int j){x(i, j) += y(i, j);});

--- a/bindings/python/src/MapObjective.cpp
+++ b/bindings/python/src/MapObjective.cpp
@@ -30,7 +30,7 @@ void mpart::binding::MapObjectiveWrapper(py::module &m) {
 
     py::class_<KLObjective<MemorySpace>, MapObjective<MemorySpace>, std::shared_ptr<KLObjective<MemorySpace>>>(m, t2Name.c_str());
     m.def(mName.c_str(), [](Eigen::Ref<Eigen::MatrixXd> &train, unsigned int dim){
-            StridedMatrix<const double, MemorySpace> trainView = MatToKokkos<double, MemorySpace>(train);
+            StridedMatrix<const double, MemorySpace> trainView = RowMatToKokkos<double, MemorySpace>(train);
             Kokkos::View<double**,MemorySpace> storeTrain ("Training data store", trainView.extent(0), trainView.extent(1));
             Kokkos::deep_copy(storeTrain, trainView);
             trainView = storeTrain;

--- a/bindings/python/src/ParameterizedFunctionBase.cpp
+++ b/bindings/python/src/ParameterizedFunctionBase.cpp
@@ -93,7 +93,7 @@ void mpart::binding::ParameterizedFunctionBaseWrapper<mpart::DeviceSpace>(py::mo
     // ParameterizedFunctionBase
     py::class_<ParameterizedFunctionBase<mpart::DeviceSpace>, std::shared_ptr<ParameterizedFunctionBase<mpart::DeviceSpace>>>(m, "dParameterizedFunctionBase")
         .def("CoeffMap", [](const ParameterizedFunctionBase<mpart::DeviceSpace> &f) {
-            Kokkos::View<const double*, Kokkos::HostSpace> host_coeffs = ToHost<mpart::DeviceSpace, const double*>( f.Coeffs() );
+            Kokkos::View<const double*, Kokkos::HostSpace> host_coeffs = ToHost( f.Coeffs() );
             return Eigen::VectorXd(Eigen::Map<const Eigen::VectorXd>(host_coeffs.data(), host_coeffs.size()));
         })
         .def("SetCoeffs", py::overload_cast<Eigen::Ref<Eigen::VectorXd>>(&ParameterizedFunctionBase<mpart::DeviceSpace>::SetCoeffs))

--- a/bindings/python/src/Wrapper.cpp
+++ b/bindings/python/src/Wrapper.cpp
@@ -40,8 +40,9 @@ PYBIND11_MODULE(pympart, m) {
     MapFactoryWrapper<mpart::DeviceSpace>(m);
     AffineMapWrapperDevice(m);
     AffineFunctionWrapperDevice(m);
-    IdentityMapWrapper<Kokkos::DeviceSpace>(m);
-    SerializeWrapper<mpart::DeviceSpace>(m);
+    IdentityMapWrapper<mpart::DeviceSpace>(m);
+#if defined(MPART_HAS_CEREAL)
     DeserializeWrapper<mpart::DeviceSpace>(m);
+#endif
 #endif
 }

--- a/src/AffineMap.cpp
+++ b/src/AffineMap.cpp
@@ -56,7 +56,8 @@ template<typename MemorySpace>
 void AffineMap<MemorySpace>::LogDeterminantImpl(StridedMatrix<const double, MemorySpace> const& pts,
                                                 StridedVector<double, MemorySpace>              output)
 {
-    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy{0lu,output.size()};
+    unsigned int N = output.size();
+    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy{0u, N};
 
     Kokkos::parallel_for(policy, KOKKOS_CLASS_LAMBDA(const int& i) {
         output(i) = logDet_;

--- a/src/AffineMap.cpp
+++ b/src/AffineMap.cpp
@@ -56,7 +56,7 @@ template<typename MemorySpace>
 void AffineMap<MemorySpace>::LogDeterminantImpl(StridedMatrix<const double, MemorySpace> const& pts,
                                                 StridedVector<double, MemorySpace>              output)
 {
-    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy{0,output.size()};
+    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy{0lu,output.size()};
 
     Kokkos::parallel_for(policy, KOKKOS_CLASS_LAMBDA(const int& i) {
         output(i) = logDet_;

--- a/src/Distributions/DensityBase.cpp
+++ b/src/Distributions/DensityBase.cpp
@@ -1,72 +1,102 @@
 #include "MParT/Distributions/DensityBase.h"
+#include "MParT/Utilities/ArrayConversions.h"
 
 using namespace mpart;
 
-template<>
-Eigen::VectorXd DensityBase<Kokkos::HostSpace>::LogDensity(Eigen::Ref<const Eigen::RowMatrixXd> const &pts) {
+template<typename MemorySpace>
+Eigen::VectorXd DensityBase<MemorySpace>::LogDensity(Eigen::Ref<const Eigen::RowMatrixXd> const &pts) {
     // Allocate output
     Eigen::VectorXd output(pts.cols());
-    StridedMatrix<const double, Kokkos::HostSpace> ptsView = ConstRowMatToKokkos<double, Kokkos::HostSpace>(pts);
-    StridedVector<double, Kokkos::HostSpace> outView = VecToKokkos<double, Kokkos::HostSpace>(output);
+    StridedVector<double, Kokkos::HostSpace> outView_h = VecToKokkos<double, Kokkos::HostSpace>(output);
+    StridedMatrix<const double, MemorySpace> ptsView_d = ConstRowMatToKokkos<double, MemorySpace>(pts);
+    StridedVector<double, MemorySpace> outView_d;
+    if constexpr(std::is_same_v<MemorySpace, Kokkos::HostSpace>) outView_d = outView_h;
+    else outView_d = Kokkos::View<double*, MemorySpace> {"Outview device", ptsView_d.extent(1)};
     // Call the LogDensity function
-    LogDensityImpl(ptsView, outView);
-
+    LogDensityImpl(ptsView_d, outView_d);
+    Kokkos::deep_copy(outView_h, outView_d);
     return output;
 }
 
-template<>
-Eigen::RowMatrixXd DensityBase<Kokkos::HostSpace>::LogDensityInputGrad(Eigen::Ref<const Eigen::RowMatrixXd> const &pts) {
+template<typename MemorySpace>
+Eigen::RowMatrixXd DensityBase<MemorySpace>::LogDensityInputGrad(Eigen::Ref<const Eigen::RowMatrixXd> const &pts) {
     // Allocate output
     Eigen::RowMatrixXd output(pts.rows(), pts.cols());
-    StridedMatrix<const double, Kokkos::HostSpace> ptsView = ConstRowMatToKokkos<double, Kokkos::HostSpace>(pts);
-    StridedMatrix<double, Kokkos::HostSpace> outView = MatToKokkos<double, Kokkos::HostSpace>(output);
+    StridedMatrix<double, Kokkos::HostSpace> outView_h = MatToKokkos<double, Kokkos::HostSpace>(output);
+    StridedMatrix<const double, MemorySpace> ptsView_d = ConstRowMatToKokkos<double, MemorySpace>(pts);
+    StridedMatrix<double, MemorySpace> outView_d;
+    if constexpr(std::is_same_v<MemorySpace, Kokkos::HostSpace>) outView_d = outView_h;
+    else outView_d = MatToKokkos<double, MemorySpace>(output); // TODO: Could be optimized
     // Call the LogDensity function
-    LogDensityInputGradImpl(ptsView, outView);
-
+    LogDensityInputGradImpl(ptsView_d, outView_d);
+    Kokkos::deep_copy(outView_h, outView_d);
     return output;
 }
 
-template<>
-template<>
-StridedVector<double, Kokkos::HostSpace> DensityBase<Kokkos::HostSpace>::LogDensity<Kokkos::HostSpace>(StridedMatrix<const double, Kokkos::HostSpace> const &X) {
+template<typename MemorySpace>
+StridedVector<double, MemorySpace> DensityBase<MemorySpace>::LogDensity(StridedMatrix<const double, MemorySpace> const &X) {
     // Allocate output
-    Kokkos::View<double*, Kokkos::HostSpace> output("output", X.extent(1));
-    // Call the LogDensity function
-    LogDensityImpl(X, output);
-
-    return output;
-}
-
-template<>
-template<>
-StridedVector<double, mpart::DeviceSpace> DensityBase<mpart::DeviceSpace>::LogDensity<mpart::DeviceSpace>(StridedMatrix<const double, mpart::DeviceSpace> const &X) {
-    // Allocate output
-    Kokkos::View<double*, mpart::DeviceSpace> output("output", X.extent(1));
+    Kokkos::View<double*, MemorySpace> output("output", X.extent(1));
     // Call the LogDensity function
     LogDensityImpl(X, output);
-
     return output;
 }
 
-
-template<>
-template<>
-StridedMatrix<double, Kokkos::HostSpace> DensityBase<Kokkos::HostSpace>::LogDensityInputGrad<Kokkos::HostSpace>(StridedMatrix<const double, Kokkos::HostSpace> const &X) {
+template<typename MemorySpace>
+StridedMatrix<double, MemorySpace> DensityBase<MemorySpace>::LogDensityInputGrad(StridedMatrix<const double, MemorySpace> const &X) {
     // Allocate output
-    Kokkos::View<double**, Kokkos::HostSpace> output("output", X.extent(0), X.extent(1));
+    Kokkos::View<double**, MemorySpace> output("output", X.extent(0), X.extent(1));
     // Call the LogDensity function
     LogDensityInputGradImpl(X, output);
 
     return output;
 }
 
-template<>
-template<>
-StridedMatrix<double, mpart::DeviceSpace> DensityBase<mpart::DeviceSpace>::LogDensityInputGrad<mpart::DeviceSpace>(StridedMatrix<const double, mpart::DeviceSpace> const &X) {
-    // Allocate output
-    Kokkos::View<double**, mpart::DeviceSpace> output("output", X.extent(0), X.extent(1));
-    // Call the LogDensity function
-    LogDensityInputGradImpl(X, output);
+#if defined(MPART_ENABLE_GPU)
 
-    return output;
+template<>
+StridedVector<double, Kokkos::HostSpace> DensityBase<DeviceSpace>::LogDensity(StridedMatrix<const double, Kokkos::HostSpace> const &X) {
+    StridedMatrix<const double, DeviceSpace> X_d = ToDevice<DeviceSpace>(X);
+    // Allocate output
+    Kokkos::View<double*, DeviceSpace> output_d("output", X.extent(1));
+    // Call the LogDensity function
+    LogDensityImpl(X_d, output_d);
+    return ToHost(output_d);
 }
+
+template<>
+StridedVector<double, DeviceSpace> DensityBase<Kokkos::HostSpace>::LogDensity(StridedMatrix<const double, DeviceSpace> const &X) {
+    StridedMatrix<const double, Kokkos::HostSpace> X_h = ToHost(X);
+    // Allocate output
+    Kokkos::View<double*, Kokkos::HostSpace> output_h("output", X.extent(1));
+    // Call the LogDensity function
+    LogDensityImpl(X_h, output_h);
+    return ToDevice<DeviceSpace>(output_h);
+}
+
+template<>
+StridedMatrix<double, Kokkos::HostSpace> DensityBase<DeviceSpace>::LogDensityInputGrad(StridedMatrix<const double, Kokkos::HostSpace> const &X) {
+    StridedMatrix<const double, DeviceSpace> X_d = ToDevice<DeviceSpace>(X);
+    // Allocate output
+    Kokkos::View<double**, DeviceSpace> output_d("output", X.extent(0), X.extent(1));
+    // Call the LogDensityInputGrad function
+    LogDensityInputGradImpl(X_d, output_d);
+    return ToHost(output_d);
+}
+
+template<>
+StridedMatrix<double, DeviceSpace> DensityBase<Kokkos::HostSpace>::LogDensityInputGrad(StridedMatrix<const double, DeviceSpace> const &X) {
+    StridedMatrix<const double, Kokkos::HostSpace> X_h = ToHost(X);
+    // Allocate output
+    Kokkos::View<double**, Kokkos::HostSpace> output_h("output", X.extent(0), X.extent(1));
+    // Call the LogDensityInputGrad function
+    LogDensityInputGradImpl(X_h, output_h);
+    return ToDevice<DeviceSpace>(output_h);
+}
+
+#endif
+
+template class mpart::DensityBase<Kokkos::HostSpace>;
+#if defined(MPART_ENABLE_GPU)
+    template class mpart::DensityBase<mpart::DeviceSpace>;
+#endif

--- a/src/Distributions/GaussianSamplerDensity.cpp
+++ b/src/Distributions/GaussianSamplerDensity.cpp
@@ -21,12 +21,12 @@ GaussianSamplerDensity<MemorySpace>::GaussianSamplerDensity(unsigned int dim): S
 template<typename MemorySpace>
 void GaussianSamplerDensity<MemorySpace>::LogDensityImpl(StridedMatrix<const double, MemorySpace> const &pts, StridedVector<double, MemorySpace> output) {
     // Compute the log density
-    int M = pts.extent(0);
-    int N = pts.extent(1);
+    unsigned int M = pts.extent(0);
+    unsigned int N = pts.extent(1);
     if(M != dim_) {
         throw std::runtime_error("GaussianSamplerDensity::LogDensityImpl: The number of rows in pts must match the dimension of the distribution.");
     }
-    Kokkos::MDRangePolicy<Kokkos::Rank<2>, typename MemoryToExecution<MemorySpace>::Space> policy({{0, 0}}, {{N, M}});
+    Kokkos::MDRangePolicy<Kokkos::Rank<2>, typename MemoryToExecution<MemorySpace>::Space> policy {{0u, 0u}, {N, M}};
     Kokkos::View<double**, Kokkos::LayoutLeft, MemorySpace> diff ("diff", M, N);
 
     if(mean_.extent(0) == 0){
@@ -44,7 +44,7 @@ void GaussianSamplerDensity<MemorySpace>::LogDensityImpl(StridedMatrix<const dou
         covChol_.solveInPlaceL(diff);
     }
 
-    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy1d{0, N};
+    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy1d{0u, N};
     Kokkos::parallel_for(policy1d, KOKKOS_CLASS_LAMBDA(const int& j){
         output(j) = -0.5*( M*logtau_ + logDetCov_ );
         for(int d=0; d<M; ++d){

--- a/src/MultiIndices/FixedMultiIndexSet.cpp
+++ b/src/MultiIndices/FixedMultiIndexSet.cpp
@@ -194,7 +194,7 @@ FixedMultiIndexSet<MemorySpace>::FixedMultiIndexSet(unsigned int                
 {
     DimensionSorter<MemorySpace> dimSort {nzStarts, nzDims, nzOrders};
     // Sort so that nzDims increases for each multiindex
-    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy{0, nzStarts.extent(0)-1};
+    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy{0lu, nzStarts.extent(0)-1};
     Kokkos::parallel_for(policy, dimSort);
 
     CalculateMaxDegrees();

--- a/src/MultiIndices/FixedMultiIndexSet.cpp
+++ b/src/MultiIndices/FixedMultiIndexSet.cpp
@@ -194,7 +194,8 @@ FixedMultiIndexSet<MemorySpace>::FixedMultiIndexSet(unsigned int                
 {
     DimensionSorter<MemorySpace> dimSort {nzStarts, nzDims, nzOrders};
     // Sort so that nzDims increases for each multiindex
-    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy{0lu, nzStarts.extent(0)-1};
+    unsigned int N_midxs = nzStarts.extent(0) - 1;
+    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy{0lu, N_midxs};
     Kokkos::parallel_for(policy, dimSort);
 
     CalculateMaxDegrees();

--- a/tests/Distributions/Test_TransportSampler.cpp
+++ b/tests/Distributions/Test_TransportSampler.cpp
@@ -11,6 +11,8 @@
 using namespace mpart;
 using namespace Catch;
 
+using MemorySpace = Kokkos::HostSpace;
+
 TEST_CASE( "Testing Pullback/Pushforward sampling", "[PullbackPushforwardSampler]") {
     unsigned int dim = 2;
     unsigned int N_samp = 10000;
@@ -41,7 +43,7 @@ TEST_CASE( "Testing Pullback/Pushforward sampling", "[PullbackPushforwardSampler
         auto pullbackSamples = pullback.Sample(N_samp);
 
         // Calculate the pullback and pushforward density error
-        auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {N_samp, dim});
+        auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<2>, typename MemoryToExecution<MemorySpace>::Space>({0, 0}, {N_samp, dim});
         Kokkos::parallel_for("Normalize Pullback Samples", policy, KOKKOS_LAMBDA(const int j, const int i) {
             pullbackSamples(i,j) *= diag_el;
             pullbackSamples(i,j) += mean;
@@ -58,7 +60,7 @@ TEST_CASE( "Testing Pullback/Pushforward sampling", "[PullbackPushforwardSampler
         auto pushforwardSamples = pushforward.Sample(N_samp);
 
         // Calculate the pullback and pushforward density error
-        auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {N_samp, dim});
+        auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<2>, typename MemoryToExecution<MemorySpace>::Space>({0, 0}, {N_samp, dim});
         Kokkos::parallel_for("Normalize Samples", policy, KOKKOS_LAMBDA(const int j, const int i) {
             pushforwardSamples(i,j) -= mean;
             pushforwardSamples(i,j) /= diag_el;

--- a/tests/Test_MapObjective.cpp
+++ b/tests/Test_MapObjective.cpp
@@ -46,10 +46,7 @@ TEST_CASE( "Test KLMapObjective", "[KLMapObjective]") {
     const double coeff_def = 1.;
 
     auto map = MapFactory::CreateTriangular<Kokkos::HostSpace>(dim, dim, 2);
-    Kokkos::RangePolicy<typename MemoryToExecution<Kokkos::HostSpace>::Space> policy(0, map->numCoeffs);
-    Kokkos::parallel_for("Fill coeffs", policy, KOKKOS_LAMBDA(const unsigned int i){
-        map->Coeffs()(i) = coeff_def;
-    });
+    Kokkos::deep_copy(map->Coeffs(), coeff_def);
 
     SECTION("CoeffGradImpl"){
         double fd_step = 1e-6;

--- a/tests/Test_PositiveBijectors.cpp
+++ b/tests/Test_PositiveBijectors.cpp
@@ -4,6 +4,7 @@
 
 #include "MParT/PositiveBijectors.h"
 #include "MParT/Utilities/ArrayConversions.h"
+#include "MParT/Utilities/KokkosSpaceMappings.h"
 
 using namespace mpart;
 using namespace Catch;
@@ -50,10 +51,11 @@ TEST_CASE( "Testing soft plus function on device.", "[SofPlusDevice]" ) {
 
     auto xs_device = ToDevice<Kokkos::DefaultExecutionSpace::memory_space>(xs_host);
 
-    Kokkos::View<double*,Kokkos::DefaultExecutionSpace::memory_space> ys_device("ys_device", xs_host.extent(0));
-    Kokkos::View<double*,Kokkos::DefaultExecutionSpace::memory_space> deriv_device("deriv_device", xs_host.extent(0));
-    
-    Kokkos::parallel_for(xs_host.size(), KOKKOS_LAMBDA(const size_t ind){
+    unsigned int N_p = xs_host.extent(0);
+    Kokkos::View<double*,DeviceSpace> ys_device("ys_device", N_p);
+    Kokkos::View<double*,DeviceSpace> deriv_device("deriv_device", N_p);
+    Kokkos::RangePolicy<typename MemoryToExecution<DeviceSpace>::Space> policy {0u, N_p};
+    Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const size_t ind){
         ys_device(ind) = SoftPlus::Evaluate(xs_device(ind));
         deriv_device(ind) = SoftPlus::Derivative(xs_device(ind));
     });

--- a/tests/Test_Quadrature.cpp
+++ b/tests/Test_Quadrature.cpp
@@ -333,7 +333,6 @@ TEST_CASE( "Testing CC Quadrature on device", "[ClenshawCurtisDevice]" ) {
     unsigned int numRepeats = 320;
 
     // Set tolerance for tests
-    double testTol = 1e-8;
     double lb = 0;
     double ub = 1.0;
 
@@ -383,7 +382,6 @@ TEST_CASE( "Testing Adaptive Simpson Quadrature on device", "[AdaptiveSimpsonDev
     double absTol = 1e-6;
     
     // Set tolerance for tests
-    double testTol = 1e-4;
     double lb = 0;
     double ub = 1.0;
 
@@ -432,7 +430,6 @@ TEST_CASE( "Testing Adaptive Clenshaw Curtis on device", "[AdaptiveCCDevice]" ) 
     unsigned int order = 8;
 
     // Set tolerance for tests
-    double testTol = 1e-4;
     double lb = 0;
     double ub = 1.0;
 

--- a/tests/Test_RootFinding.cpp
+++ b/tests/Test_RootFinding.cpp
@@ -70,7 +70,7 @@ TEST_CASE( "RootFindingUtils", "[RootFindingUtils]") {
         CHECK(info==0);
     }
     SECTION("Test Inverse Flat") {
-        double xd = 0.5, yd = 0.0;
+        double yd = 0.0;
         double x0 = 0.0, xtol = 1e-5, ftol = 1e-5;
         auto f = [](double x){return -1.0;};
         int info = 0;

--- a/tests/Test_Sigmoid.cpp
+++ b/tests/Test_Sigmoid.cpp
@@ -15,7 +15,8 @@ template<typename Function>
 void TestSigmoidGradients(Function Sigmoid, unsigned int N_grad_points, double fd_delta) {
     Kokkos::View<double*, MemorySpace> gradPts("Gradient points", N_grad_points);
     Kokkos::View<double*, MemorySpace> gradPts_plus_delta("Gradient points plus delta", N_grad_points);
-    Kokkos::parallel_for(N_grad_points, KOKKOS_LAMBDA(unsigned int point_index) {
+    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy {0u, N_grad_points};
+    Kokkos::parallel_for(policy, KOKKOS_LAMBDA(unsigned int point_index) {
         double gradPt = 3.0*(-1.0 + 2*((double) point_index)/((double) N_grad_points-1));
         gradPts(point_index) = gradPt;
         gradPts_plus_delta(point_index) = gradPt + fd_delta;

--- a/tests/Test_SummarizedMap.cpp
+++ b/tests/Test_SummarizedMap.cpp
@@ -41,7 +41,6 @@ TEST_CASE( "SummarizedMap", "[SummarizedMap_MonotoneComponent]" ) {
         sumMap->SetCoeffs(coeffs);
 
         // Now make sure that the coefficients of each block were set
-        unsigned int cumCoeffInd = 0;
         for(unsigned int i=0; i<sumMap->numCoeffs; ++i){
             CHECK(sumMap->Coeffs()(i) == 0.1*(i+1)); // Values of coefficients should be correct
             CHECK(sumMap->Coeffs()(i) == comp->Coeffs()(i)); // Values of coefficients should be equal to those of comp

--- a/tests/Test_TrainMapAdaptive.cpp
+++ b/tests/Test_TrainMapAdaptive.cpp
@@ -10,6 +10,7 @@ using namespace Catch;
 
 #include "MParT/Utilities/LinearAlgebra.h"
 #include "Distributions/Test_Distributions_Common.h"
+using MemorySpace = Kokkos::HostSpace;
 
 void NormalizeSamples(StridedMatrix<double, Kokkos::HostSpace> mat) {
     using MemorySpace = Kokkos::HostSpace;
@@ -154,7 +155,8 @@ TEST_CASE("Adaptive Transport Map","[ATM]") {
     // }
     SECTION("TraditionalBananaOneComp") {
         Kokkos::View<double**, Kokkos::HostSpace> targetSamples("targetSamples", 2, numPts);
-        Kokkos::parallel_for("Intializing targetSamples", numPts, KOKKOS_LAMBDA(const unsigned int i){
+        Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy {0u, numPts};
+        Kokkos::parallel_for("Intializing targetSamples", policy, KOKKOS_LAMBDA(const unsigned int i){
             targetSamples(0,i) = samples(0,i);
             targetSamples(1,i) = samples(1,i) + samples(0,i)*samples(0,i);
         });

--- a/tests/Test_TriangularMap.cpp
+++ b/tests/Test_TriangularMap.cpp
@@ -584,7 +584,6 @@ TEST_CASE( "Testing TriangularMap made using CreateSingleEntryMap", "[Triangular
         triMap->SetCoeffs(coeffs);
 
         // Now make sure that the coefficients of each block were set
-        unsigned int cumCoeffInd = 0;
         for(unsigned int i=0; i<triMap->numCoeffs; ++i){
                 CHECK(comp->Coeffs()(i) == triMap->Coeffs()(i)); // Values of coefficients should be equal
                 CHECK(&comp->Coeffs()(i) == &triMap->Coeffs()(i)); // Memory location should also be the same (no copy)
@@ -604,9 +603,6 @@ TEST_CASE( "Testing TriangularMap made using CreateSingleEntryMap", "[Triangular
     auto out = triMap->Evaluate(in);
 
     SECTION("Evaluation"){
-
-        unsigned int start = 0;
-
 
         auto inTop = Kokkos::subview(in, std::make_pair(0, int(activeInd-1)), Kokkos::ALL());
         auto inTopAndMid = Kokkos::subview(in, std::make_pair(0, int(activeInd)), Kokkos::ALL());


### PR DESCRIPTION
Take a look at the changes. A bunch of these fixes are to avoid type conversion warnings, or otherwise are superficial. Major changes are in `DensityBase.h` and `.cpp`, because those weren't very robust when I implemented them my last go-round. I took a cue from how you implemented `SetCoeffs` (I think it was really well-done!).